### PR TITLE
global: addition of search access control

### DIFF
--- a/cap/config.py
+++ b/cap/config.py
@@ -100,7 +100,7 @@ SECURITY_SEND_REGISTER_EMAIL=False
 THEME_SITENAME = _("CERN Analysis Preservation")
 THEME_LOGO =  "img/cap_logo_lrg.svg"
 # REQUIREJS_CONFIG = 'js/build.js'
-THEME_GOOGLE_SITE_VERIFICATION =  []
+THEME_GOOGLE_SITE_VERIFICATION = []
 BASE_TEMPLATE = "cap_theme/page.html"
 SECURITY_LOGIN_USER_TEMPLATE = "access/login_user.html"
 # config.setdefault(
@@ -123,3 +123,7 @@ SECURITY_LOGIN_USER_TEMPLATE = "access/login_user.html"
 #     'THEME_404_TEMPLATE', 'invenio_theme/404.html')
 # config.setdefault(
 #     'THEME_500_TEMPLATE', 'invenio_theme/500.html')
+
+SEARCH_QUERY_ENHANCERS = [
+    'cap.modules.access.ext:authenticated_query'
+]

--- a/cap/modules/access/ext.py
+++ b/cap/modules/access/ext.py
@@ -3,9 +3,12 @@
 from __future__ import absolute_import, print_function
 
 import redis
-
+from flask import session
 from flask_kvsession import KVSessionExtension
+from invenio_query_parser.ast import (AndOp, DoubleQuotedValue, Keyword,
+                                      KeywordOp, OrOp, NotOp)
 from simplekv.memory.redisstore import RedisStore
+
 
 class Access(object):
     """Access extension."""
@@ -21,3 +24,66 @@ class Access(object):
         """Initialize configuration."""
         app.config.setdefault("SECURITY_LOGIN_USER_TEMPLATE",
                               "access/login_user.html")
+        app.extensions['cap-access'] = self
+
+
+def authenticated_query(query, **kwargs):
+    """Enhance query with user authentication rules."""
+
+    collaborations_dictionary = {
+        'collaboration_alice': [],
+        'collaboration_atlas': [
+            KeywordOp(
+                    Keyword('collections'),
+                    DoubleQuotedValue('atlasworkflows'))
+        ],
+        'collaboration_cms': [
+            KeywordOp(
+                    Keyword('collections'),
+                    DoubleQuotedValue('cmsanalysis')),
+            KeywordOp(
+                    Keyword('collections'),
+                    DoubleQuotedValue('cmsquestionnaire'))
+        ],
+        'collaboration_lhcb': [
+            KeywordOp(
+                    Keyword('collections'),
+                    DoubleQuotedValue('lhcbanalysis'))
+        ]
+    }
+
+    if 'identity.provides' in session:
+        ast_expressions = []
+        for need in session['identity.provides']:
+            if need.method == 'role':
+                if need.value in collaborations_dictionary:
+                    for item in collaborations_dictionary[need.value]:
+                        ast_expressions.append(item)
+
+        if len(ast_expressions) >= 1:
+            query.query = AndOp(
+                generate_query_ast(ast_expressions, 0, len(ast_expressions)),
+                query.query
+            )
+            return
+
+    query.query = AndOp(
+        query.query,
+        KeywordOp(
+            Keyword('collections'),
+            DoubleQuotedValue('public')),
+    )
+
+
+def generate_query_ast(items, begin, end):
+    """Generate the AST of an Or query with the list of items."""
+    if end - begin == 1:
+        return items[begin]
+    elif end - begin == 2:
+        return OrOp(items[begin], items[begin + 1])
+    else:
+        middle = begin + (end - begin) / 2
+        return OrOp(
+            generate_query_ast(items, begin, middle),
+            generate_query_ast(items, middle, end)
+        )

--- a/setup.py
+++ b/setup.py
@@ -138,6 +138,7 @@ setup(
         'invenio_base.api_apps': [
             'invenio_pidstore = invenio_pidstore:InvenioPIDStore',
             'invenio_search = invenio_search:InvenioSearch',
+            'cap_access = cap.modules.access.ext:Access',
         ],
         'invenio_access.actions': [
             'cap_alice_access = cap.modules.experiments.views.alice:alice_group_need',


### PR DESCRIPTION
* Adds a query enhancer that filters the results of a search to
  retrieve only the records that the user has permissions to see.

Signed-off-by: Javier Delgado <javier.delgado.fernandez@cern.ch>