### PR TITLE
LHCb: software name version separation

### DIFF
--- a/cap/modules/records/jsonschemas/options/LHCbAnalysis.js
+++ b/cap/modules/records/jsonschemas/options/LHCbAnalysis.js
@@ -62,12 +62,28 @@ window.schemaOptions = {
 						"placeholder": "E.g. 2015"
                       },
                       "reconstruction_software": {
-                        "order": 2,
-						"placeholder": "E.g. Brunel Reco 13"
+						"order": 2,
+						"type": "depositgroup-object",
+						"fields": {
+						  "reconstruction_software_name": {
+                            "placeholder": "E.g. Brunel Reco"
+						  },
+						   "reconstruction_software_version": {
+                            "placeholder": "E.g. 13"
+						  }
+                        }
                       },
                       "stripping_software": {
-                        "order": 3,
-                        "placeholder": "E.g. DaVinciStripping 17"
+						"order": 3,
+						"type": "depositgroup-object",
+						"fields": {
+						  "stripping_software_name": {
+                            "placeholder": "E.g. DaVinciStripping"
+						  },
+						   "stripping_software_version": {
+                            "placeholder": "E.g. 17"
+						  }
+                        }
                       },
                       "location": {
                         "order": 1,
@@ -92,12 +108,28 @@ window.schemaOptions = {
                         "placeholder": "E.g. MC Gen"
                       },
                       "reconstruction_software": {
-                        "order": 4,
-                        "placeholder": "E.g. MC Reco 11"
+						"order": 4,
+						"type": "depositgroup-object",
+						"fields": {
+						  "reconstruction_software_name": {
+                            "placeholder": "E.g. MC Reco"
+						  },
+						   "reconstruction_software_version": {
+                            "placeholder": "E.g. 11"
+						  }
+                        }
                       },
                       "stripping_software": {
-                        "order": 5,
-                        "placeholder": "E.g. MC Strip 16"
+						"order": 5,
+						"type": "depositgroup-object",
+						"fields": {
+						  "stripping_software_name": {
+                            "placeholder": "E.g. MC Strip"
+						  },
+						   "stripping_software_version": {
+                            "placeholder": "E.g. 16"
+						  }
+                        }
                       },
                       "location": {
                         "order": 1,

--- a/cap/modules/records/jsonschemas/records/LHCbAnalysis.json
+++ b/cap/modules/records/jsonschemas/records/LHCbAnalysis.json
@@ -51,12 +51,32 @@
                     "type": "string"
                   },
                   "reconstruction_software": {
-                    "title": "Reconstruction software",
-                    "type": "string"
+					"title": "Reconstruction software",
+					"type": "object",
+					"properties": {
+					  "reconstruction_software_name": {
+                        "title": "Name",
+                        "type": "string"
+                      },
+                      "reconstruction_software_version": {
+                        "title": "Version",
+                        "type": "string"
+                      }
+                    }
                   },
                   "stripping_software": {
-                    "title": "Stripping software",
-                    "type": "string"
+					"title": "Stripping software",
+					"type": "object",
+					"properties": {
+					  "stripping_software_name": {
+                        "title": "Name",
+                        "type": "string"
+                      },
+                      "stripping_software_version": {
+                        "title": "Version",
+                        "type": "string"
+                      }
+                    }
                   },
                   "location": {
                     "title": "Location",
@@ -80,12 +100,32 @@
                     "type": "string"
                   },
                   "reconstruction_software": {
-                    "title": "Reconstruction software",
-                    "type": "string"
+					"title": "Reconstruction software",
+					"type": "object",
+					"properties": {
+					  "reconstruction_software_name": {
+                        "title": "Name",
+                        "type": "string"
+                      },
+                      "reconstruction_software_version": {
+                        "title": "Version",
+                        "type": "string"
+                      }
+                    }
                   },
                   "stripping_software": {
-                    "title": "Stripping software",
-                    "type": "string"
+					"title": "Stripping software",
+					"type": "object",
+					"properties": {
+					  "stripping_software_name": {
+                        "title": "Name",
+                        "type": "string"
+                      },
+                      "stripping_software_version": {
+                        "title": "Version",
+                        "type": "string"
+                      }
+                    }
                   },
                   "location": {
                     "title": "Location",


### PR DESCRIPTION
* Introduces two text fields for every software field to put in name and
version separately (closes #125).

Signed-off-by: Annemarie Mattmann <annemarie.mattmann@cern.ch>