### PR TITLE
docs: install guide update

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -114,18 +114,11 @@ depend on:
    npm install bower
    npm install
 
-Install alpaca:
+Build the assets from your repository folder:
 
 .. code-block:: shell
 
-   cd node_modules/alpaca
-   npm install
-
-Build the assets:
-
-.. code-block:: shell
-
-   cd cap
+   cd -
    cap collect -v
    cap assets build
    python ./scripts/schemas.py
@@ -243,15 +236,6 @@ following requirements:
 
 The version of python2 given by ``python2 --version`` should be greater
 than 2.7.10.
-
-Errors with Alpaca
-""""""""""""""""""
-If alpaca does not install correctly try:
-
-.. code-block:: shell
-
-   npm install gulp gulp-clean jshint gulp-jshint
-   npm install
 
 Database Indexing Problems
 """"""""""""""""""""""""""

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -156,7 +156,6 @@ Install alpaca:
 
    cd node_modules/alpaca
    npm install
-   npm start
 
 Build the assets:
 
@@ -269,7 +268,7 @@ Troubleshooting
 
 Missing Requirements
 """"""""""""""""""""
-If you have trouble with the setup check if you are missing one of the
+If you have trouble with the setup, check if you are missing one of the
 following requirements:
 
 .. code-block:: shell
@@ -279,33 +278,14 @@ following requirements:
 The version of python2 given by ``python2 --version`` should be greater
 than 2.7.10.
 
-Errors with ``npm start`` and Alpaca
-""""""""""""""""""""""""""""""""""""
-If ``npm start`` fails for alpaca, you can try:
+Errors with Alpaca
+""""""""""""""""""
+If alpaca does not install correctly try:
 
 .. code-block:: shell
 
    npm install gulp gulp-clean jshint gulp-jshint
    npm install
-   npm start   
-
-If it fails because it is missing a gulpfile, try the following:
-
-.. code-block:: shell
-
-   cdvirtualenv var/cap-instance/static/node_modules
-   wget https://github.com/gitana/alpaca/archive/1.5.17.tar.gz
-   tar -xvf 1.5.17.tar.gz
-   mv alpaca-1.5.17/ alpaca
-   cd alpaca
-
-and then repeat
-
-.. code-block:: shell
-
-   npm install gulp gulp-clean jshint gulp-jshint
-   npm install
-   npm start 
 
 Database Indexing Problems
 """"""""""""""""""""""""""

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -102,8 +102,9 @@ Debian GNU/Linux the full path is
   http.port: 9200
   http.publish_port: 9200
 
-Finally, do a system install (see below for how to do a local install
-instead) for the Sass preprocessor by following
+Finally, do a system-wide install (see below for how to do a local
+install enclosed inside your virtual environment instead) for the Sass
+preprocessor by following
 `Sass web guide <http://sass-lang.com/install>`_ and running:
 
 .. code-block:: shell
@@ -123,9 +124,13 @@ Environment Setup
 """""""""""""""""
 
 All else will be installed inside a python *virtualenv* for easy
-maintenance and encapsulation of the libraries required. To do so,
-create a new virtual environment to hold our CAP instance
-from inside the repository folder:
+maintenance and encapsulation of the libraries required. From inside
+your `cap` folder you can choose anytime whatever virtual environment
+you want to work on (just type `workon virtualenv_installed`) or you can
+choose to create a new one.
+
+To do the latter, create a new virtual environment to hold our CAP
+instance from inside the repository folder:
 
 .. code-block:: shell
 
@@ -244,7 +249,9 @@ creation as follows (e.g. to use python 2.7):
 Local Installation of npms and gems
 """""""""""""""""""""""""""""""""""
 
-You do not need to install sass and all npm dependencies globally if you add
+You do not need to install sass and all npm dependencies globally on
+your system. You can install them inside your virtual environment so
+they will only be accessible from within it. Simply add:
 
 .. code-block:: shell
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -19,49 +19,8 @@ Detailed Installation Guide
 ===========================
 
 There are two possibilities for setting up your own development version
-of CERN Analysis Preservation, one with docker and one with python
-virtualenvwrapper.
-
-Docker Installation
--------------------
-
-You should have installed Docker and docker-compose on your machine. Then, you
-can build the application using the development configuration:
-
-.. code-block:: shell
-
-   docker-compose -f docker-compose-dev.yml build
-
-
-Now that you have built the application inside the docker containers, you will
-need to initialize some modules. This initialization consist of the creation of
-the tables inside the database, the default user (user:
-info@inveniosoftware.org, password: infoinfo), the required communities and the
-ElasticSearch index.
-
-To initialise it then, you will need to perform:
-
-.. code-block:: shell
-
-   docker-compose run app bash scripts/init.sh
-
-
-Optionally, if you want to populate the database with some example records, you
-can run:
-
-.. code-block:: shell
-
-   docker-compose run app cap fixtures records -f
-
-
-And lately, you can start the application:
-
-.. code-block:: shell
-
-   docker-compose -f docker-compose-dev.yml up
-
-
-Now, open your browser and navigate to http://localhost/
+of CERN Analysis Preservation, one with python virtualenvwrapper and one
+with docker.
 
 
 Bare Installation
@@ -135,7 +94,7 @@ instance from inside the repository folder:
 .. code-block:: shell
 
    cd cap
-   mkvirtualenv cap_venv
+   mkvirtualenv cap
 
 Start redis server in the background:
 
@@ -244,7 +203,7 @@ creation as follows (e.g. to use python 2.7):
 
 .. code-block:: shell
 
-   mkvirtualenv -p /usr/bin/python2.7 cap_venv
+   mkvirtualenv -p /usr/bin/python2.7 cap
 
 Local Installation of npms and gems
 """""""""""""""""""""""""""""""""""
@@ -309,3 +268,45 @@ and if that does not work try:
 
    curl -XDELETE 'http://localhost:9200/_all'
    cap db init
+
+
+Docker Installation
+-------------------
+
+You should have installed Docker and docker-compose on your machine. Then, you
+can build the application using the development configuration:
+
+.. code-block:: shell
+
+   docker-compose -f docker-compose-dev.yml build
+
+
+Now that you have built the application inside the docker containers, you will
+need to initialize some modules. This initialization consist of the creation of
+the tables inside the database, the default user (user:
+info@inveniosoftware.org, password: infoinfo), the required communities and the
+ElasticSearch index.
+
+To initialise it then, you will need to perform:
+
+.. code-block:: shell
+
+   docker-compose run app bash scripts/init.sh
+
+
+Optionally, if you want to populate the database with some example records, you
+can run:
+
+.. code-block:: shell
+
+   docker-compose run app cap fixtures records -f
+
+
+And lately, you can start the application:
+
+.. code-block:: shell
+
+   docker-compose -f docker-compose-dev.yml up
+
+
+Now, open your browser and navigate to http://localhost/

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -320,6 +320,5 @@ and if that does not work try:
 
 .. code-block:: shell
 
-   curl -XDELETE 'http://localhost:9200/rec*'
-   curl -XDELETE 'http://localhost:9200/map*'
+   curl -XDELETE 'http://localhost:9200/_all'
    cap db init

--- a/cap/modules/alpaca/bundles.py
+++ b/cap/modules/alpaca/bundles.py
@@ -21,7 +21,7 @@ display_js = NpmBundle(
         "handlebars": "~4.0.5",
         "moment": "~2.10.6",
         "json-schema-ref-parser": "~1.4.0",
-        # "alpaca": "1.5.17",
+        "alpaca": "1.5.17",
         "gulp": "3.9.0",
     }
 )
@@ -45,7 +45,7 @@ create_js = NpmBundle(
         "handlebars": "~4.0.5",
         "moment": "~2.10.6",
         "json-schema-ref-parser": "~1.4.0",
-        # "alpaca": "1.5.17",
+        "alpaca": "1.5.17",
         "gulp": "3.9.0",
         "fast-json-patch": "~0.5.4",
         "jsoneditor": "~5.1.5",
@@ -71,7 +71,7 @@ edit_js = NpmBundle(
         "handlebars": "~4.0.5",
         "moment": "~2.10.6",
         "json-schema-ref-parser": "~1.4.0",
-        # "alpaca": "1.5.17",
+        "alpaca": "1.5.17",
         "gulp": "3.9.0",
         "fast-json-patch": "~0.5.4",
     }

--- a/cap/modules/theme/static/js/cap-settings.js
+++ b/cap/modules/theme/static/js/cap-settings.js
@@ -29,7 +29,7 @@ require.config({
     typeahead: "node_modules/typeahead.js/dist/typeahead.jquery",
     handlebars: "node_modules/handlebars/dist/handlebars.amd.min",
     moment: "node_modules/moment/min/moment.min",
-    alpaca: "node_modules/alpaca/build/alpaca/bootstrap/alpaca",
+    alpaca: "node_modules/alpaca/dist/alpaca/bootstrap/alpaca",
     "invenio-alpaca": "js/invenio-alpaca",
     "module-getter": "js/module-getter",
     "ref-parser": "node_modules/json-schema-ref-parser/dist/ref-parser",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
--e git+git://github.com/ioannistsanaktsidis/invenio-oauthclient.git@15d74fded735b8f293d92cc66add7018c6af0299#egg=invenio-oauthclient
+-e git+git://github.com/inveniosoftware/invenio-oauthclient.git@14bbc6c136f1466aafda4891313c563503cab95e#egg=invenio-oauthclient
 
 -e .[all]


### PR DESCRIPTION
INSTALL.rst update:

- decouples virtualenv and repository for easier testing with different library versions and easier exchange of libraries (better encapsulation) or python versions. Along with that, it adds instructions for a local install of npms and gems for even further flexibility.
- adds alpaca fix as introduced for docker in f1f7c29.

The .gitignore can be reduced to the following lines by this:
```
# Byte-compiled / optimized / DLL files
__pycache__/
*.py[cod]
*.pyc

# Distribution / packaging
.eggs/
*.egg-info/

#Certificates
*.crt
*.key

/cap/modules/records/jsonschemas_gen/*
```
but as this messes with everyone's existing setup I did not include it here.

Signed-off-by: Annemarie Mattmann <annemarie.mattmann@cern.ch>