### PR TITLE
docs: fix node-sass version

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -77,7 +77,7 @@ preprocessor by following
 
 .. code-block:: shell
 
-  sudo npm install -g node-sass clean-css uglify-js requirejs
+  sudo npm install -g node-sass@3.8.0 clean-css uglify-js requirejs
 
 Installation
 ^^^^^^^^^^^^


### PR DESCRIPTION
Solution adopted from https://github.com/inspirehep/inspire-next/commit/b566ed71f3b54c55071040e5380337623a16a76f.

Fix for the homepage looking like that:
![postsetup](https://cloud.githubusercontent.com/assets/5553636/19939446/530a554a-a129-11e6-81cb-df165c4c10ee.png)
